### PR TITLE
Update chart to use TZ

### DIFF
--- a/mailu/templates/postfix.yaml
+++ b/mailu/templates/postfix.yaml
@@ -94,6 +94,8 @@ spec:
             value: "{{ .Values.external_relay.username }}"
           - name: RELAYPASSWORD
             value: "{{ .Values.external_relay.password }}"
+          - name: TZ
+            value: "{{ default "UTC" .Values.timezone }}"
           {{- end}}
           {{- end}}
         ports:


### PR DESCRIPTION
As said in https://mailu.io/1.9/configuration.html?highlight=timezone#advanced-settings
Container will read env var `TZ` 